### PR TITLE
added transaction formatting

### DIFF
--- a/components/TransactionsTable/TransactionsTable.jsx
+++ b/components/TransactionsTable/TransactionsTable.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { getProperCurrency } from "utils/string";
+import { getProperCurrency, getProperValue } from "utils/string";
 
 const transactionsTable = ({ transactions }) => (
   <div style={{ overflow: "auto" }}>
@@ -42,13 +42,13 @@ const transactionsTable = ({ transactions }) => (
             </td>
             <td className="govuk-table__cell">{transaction.description}</td>
             <td className="govuk-table__cell govuk-table__cell--numeric">
-              {getProperCurrency(transaction.out)}
+              {getProperValue(getProperCurrency(transaction.out))}
             </td>
             <td className="govuk-table__cell govuk-table__cell--numeric">
               {getProperCurrency(transaction.in)}
             </td>
             <td className="govuk-table__cell govuk-table__cell--numeric">
-              {getProperCurrency(transaction.balance)}
+              {getProperValue(getProperCurrency(transaction.balance))}
             </td>
           </tr>
         ))}

--- a/utils/string.js
+++ b/utils/string.js
@@ -5,3 +5,10 @@ export const getPrivacyString = (string) =>
     .join(" ");
 
 export const getProperCurrency = (string) => string && string.replace("¤", "£");
+
+const MATCH_PARENTHESES = new RegExp(/\(([^)]+)\)/);
+
+export const getProperValue = (string) => {
+  const value = string.match(MATCH_PARENTHESES);
+  return value ? `-${value[1]}` : string;
+};

--- a/utils/string.spec.js
+++ b/utils/string.spec.js
@@ -1,4 +1,4 @@
-import { getPrivacyString, getProperCurrency } from "./string";
+import { getPrivacyString, getProperCurrency, getProperValue } from "./string";
 
 describe("string util", () => {
   describe("getPrivacyString", () => {
@@ -10,6 +10,22 @@ describe("string util", () => {
   describe("getProperCurrency", () => {
     it("should work properly", () => {
       expect(getProperCurrency("¤123")).toBe("£123");
+    });
+  });
+
+  describe("getProperValue", () => {
+    it("should work properly", () => {
+      expect(getProperValue("(£111.48)")).toBe("-£111.48");
+      expect(getProperValue("£123")).toBe("£123");
+      expect(getProperValue("(123)")).toBe("-123");
+    });
+  });
+
+  describe("getProperValue", () => {
+    it("should work properly", () => {
+      expect(getProperValue("(£111.48)")).toBe("-£111.48");
+      expect(getProperValue("£123")).toBe("£123");
+      expect(getProperValue("(123)")).toBe("-123");
     });
   });
 });


### PR DESCRIPTION
**What**
- The "new" AWS APIs are returning negative values between parentheses 🤷 we added a util in order to format them properly.
- Ideally, the APIs should return the value already formatted properly


<img width="657" alt="Screenshot 2020-07-17 at 09 22 41" src="https://user-images.githubusercontent.com/435399/87760032-18864380-c807-11ea-9ce2-14793ca0a863.png">
